### PR TITLE
Prevent paymentlinks having default or null date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Roadmap
 - Demo scene with Bolt quick start guide
 
+## [0.0.6] - 2025-09-18
+- Fixed an issue where payment links can be initialized with a null date
+
 ## [0.0.5] - 2025-08-03
 
 ### Fixed

--- a/Runtime/Models/PaymentLinkSession.cs
+++ b/Runtime/Models/PaymentLinkSession.cs
@@ -16,6 +16,14 @@ namespace BoltApp
         public DateTime LastAccessedAt;
         public DateTime CompletedAt;
 
+        public PaymentLinkSession()
+        {
+            // Would be considered invalid until a paymentLinkID and paymentLinkUrl are set
+            CreatedAt = DateTime.UtcNow;
+            LastAccessedAt = DateTime.UtcNow;
+            Status = PaymentLinkStatus.Pending;
+        }
+
         public PaymentLinkSession(string paymentLinkId, string paymentLinkUrl, PaymentLinkStatus status = PaymentLinkStatus.Pending)
         {
             PaymentLinkId = paymentLinkId;
@@ -34,8 +42,8 @@ namespace BoltApp
             PaymentLinkId = paymentLinkId;
             PaymentLinkUrl = paymentLinkUrl;
             Status = status;
-            CreatedAt = createdAt;
-            LastAccessedAt = lastAccessedAt;
+            CreatedAt = createdAt ?? DateTime.UtcNow;
+            LastAccessedAt = lastAccessedAt ?? DateTime.UtcNow;
             CompletedAt = completedAt;
         }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "com.bolt.sdk": "https://github.com/BoltApp/bolt-unity-sdk.git#v0.0.1"
+    "com.bolt.sdk": "https://github.com/BoltApp/bolt-unity-sdk.git#v0.0.6"
   }
 } 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.bolt.sdk",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "displayName": "Bolt SDK",
   "description": "A Unity SDK for performing in-app purchases and subscriptions outside of the app store.",
   "unity": "2021.3",


### PR DESCRIPTION
Fixes a bug where payment links can be created without passing a createdAt. This results in a null date that defaults to the year `1/1/0001`. 

Adds a default constructor and defaults the createdAt date in other constructors. 