### PR TITLE
feat!: migrate bolt.com references to boltapp.com (2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Demo scene with Bolt quick start guide
 - Serverless quick start (no game server needed)
 
+## [2.0.0] - 2026-07-20
+### Changed
+- **BREAKING:** Migrated all exact `bolt.com` references to `boltapp.com`. The default production ad host (`play.bolt.com`) now targets `play.boltapp.com`; consumers relying on the old default endpoint must update. Staging/sandbox hosts (`staging-bolt.com`, `sandbox-bolt.com`) are intentionally unchanged.
+- Updated package metadata (author name/email/url, documentation URL) and documentation/help/marketing links to `boltapp.com`.
+
 ## [1.1.1] - 2026-04-1 
 ### Added
 - Support for internal and external linkouts

--- a/README.md
+++ b/README.md
@@ -57,15 +57,15 @@ We also support other platforms:
 
 ## 📚 Documentation
 
-For further documentation and API reference visit our [Quickstart guide](https://gaming-help.bolt.com/guide/quickstart.html).
+For further documentation and API reference visit our [Quickstart guide](https://gaming-help.boltapp.com/guide/quickstart.html).
 
 ## 💰 Why Bolt
 
 Only with Bolt you get **2.1% + $0.30 on all transactions**. That's 10x better than traditional app stores which take 30% of your revenue! That's the fair and transparent pricing you get with using Bolt.
 
 > Bolt’s fees are subject to change but will remain highly competitive. 
-> For the latest rates, see [Bolt Pricing](https://www.bolt.com/pricing). 
-> For details, review the [End User Terms and Conditions](https://www.bolt.com/end-user-terms).
+> For the latest rates, see [Bolt Pricing](https://www.boltapp.com/pricing). 
+> For details, review the [End User Terms and Conditions](https://www.boltapp.com/end-user-terms).
 
 ## 🛠️ Prerequisites
 
@@ -73,7 +73,7 @@ You need 3 things to get started:
 
 1. **Existing App:** You will need an application in the same platform as this SDK
 2. **Backend Server:** You will need to bring your own backend server (any language)
-3. **Bolt Merchant Account:** Dashboard access to manage your store ([sign up](https://merchant.bolt.com/onboarding/get-started/gaming) or [log in](https://merchant.bolt.com/))
+3. **Bolt Merchant Account:** Dashboard access to manage your store ([sign up](https://merchant.boltapp.com/onboarding/get-started/gaming) or [log in](https://merchant.boltapp.com/))
 4. **UniWebViewAdService.cs** [Unity plugin supporting iOS and Android in-game webviews](https://docs.uniwebview.com/guide/)
 
 
@@ -220,7 +220,7 @@ Integration examples are also provided in the `Samples~/` folder.
 - [**BoltDeepLinkExample**](./Samples~/DeepLinkIntegration/BoltDeepLinkExample.cs): will showcase how to handle deep links back into the application.
 ### Backend Integration
 You will need to bring your own backend server to complete integration for web payments. 
-- [**Quickstart**](https://gaming-help.bolt.com/guide/quickstart.html): View our quickstart guide to get the API running
+- [**Quickstart**](https://gaming-help.boltapp.com/guide/quickstart.html): View our quickstart guide to get the API running
 - [**Example Server**](https://github.com/BoltApp/bolt-gameserver-sample): We also have a sample server in NodeJS for your reference during implementation
 
 

--- a/Runtime/Core/BoltConfig.cs
+++ b/Runtime/Core/BoltConfig.cs
@@ -50,7 +50,7 @@ namespace BoltApp
                     return "https://play.sandbox-bolt.com";
                 case Environment.Production:
                 default:
-                    return "https://play.bolt.com";
+                    return "https://play.boltapp.com";
             }
         }
 

--- a/Samples~/BasicIntegration/BoltBasicExample.cs
+++ b/Samples~/BasicIntegration/BoltBasicExample.cs
@@ -34,7 +34,7 @@ namespace BoltApp.Samples
 
             // Open A Checkout Link, typically assigned to a button click in your UI
             // Note: SDK automatically stores a pending payment link in player prefs, used in 'VerifyRecentCheckouts()'
-            var checkoutLinkFetchedFromYourBackend = "https://knights-of-valor-bolt.c-staging.bolt.com/c?u=Fv8ZMmDmRb86C4XRiB92x2&publishable_key=_Kq5XZXqaLiS.3TOhnz9Wmacb.9c59b297d066e94294895dd8617ad5d9d8ffc530fe1d36f8ed6d624a4f7855ae";
+            var checkoutLinkFetchedFromYourBackend = "https://knights-of-valor-bolt.c-staging.boltapp.com/c?u=Fv8ZMmDmRb86C4XRiB92x2&publishable_key=_Kq5XZXqaLiS.3TOhnz9Wmacb.9c59b297d066e94294895dd8617ad5d9d8ffc530fe1d36f8ed6d624a4f7855ae";
             boltSDK.OpenCheckout(checkoutLinkFetchedFromYourBackend);
 
             // Note: On app load you need to check for recent checkouts.

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "com.bolt.sdk",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "displayName": "Bolt SDK",
   "description": "A performant Unity SDK for out of app purchases, subscriptions and ads.",
   "unity": "2021.3",
   "keywords": ["bolt", "sdk", "subscription", "web payment", "iap", "checkout", "ads"],
   "license": "MIT",
   "author": {
-    "name": "bolt.com",
-    "email": "support@bolt.com",
-    "url": "https://bolt.com"
+    "name": "boltapp.com",
+    "email": "support@boltapp.com",
+    "url": "https://boltapp.com"
   },
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.2.1"
@@ -24,7 +24,7 @@
       "path": "Samples~/BasicIntegration"
     }
   ],
-  "documentationUrl": "https://docs.bolt.com/unity-sdk",
+  "documentationUrl": "https://docs.boltapp.com/unity-sdk",
   "changelogUrl": "https://github.com/BoltApp/bolt-unity-sdk/blobl/main/CHANGELOG.md",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "path": "Samples~/BasicIntegration"
     }
   ],
-  "documentationUrl": "https://docs.boltapp.com/unity-sdk",
+  "documentationUrl": "https://help.boltapp.com/unity-sdk",
   "changelogUrl": "https://github.com/BoltApp/bolt-unity-sdk/blobl/main/CHANGELOG.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Rebrand migration for the `com.bolt.sdk` Unity package: every **exact** `bolt.com` reference (and its subdomains) now points to `boltapp.com`, and the package is bumped `1.1.1 → 2.0.0`. The major bump is because the default **production ad host** changes, which is breaking for existing consumers.

The separate hyphenated environment domains `staging-bolt.com` and `sandbox-bolt.com` are intentionally left unchanged (they are their own domains, not subdomains of `bolt.com`).

### The breaking change (`Runtime/Core/BoltConfig.cs`, `GetAdUrl()`)
```diff
  Production/default:
-   return "https://play.bolt.com";
+   return "https://play.boltapp.com";
  // Staging + Sandbox cases unchanged:
  //   play.staging-bolt.com, play.sandbox-bolt.com
```

### Other changes (non-runtime, docs/metadata only)
- `package.json`: `version 1.1.1 → 2.0.0`; author `name`/`email`/`url` and `documentationUrl` → `boltapp.com`. Package name `com.bolt.sdk`, `github.com/BoltApp/...` repo URLs, and keywords left unchanged.
- `README.md`: `gaming-help`, `www` (pricing / end-user-terms), and `merchant` links → `boltapp.com`. Third-party links (`docs.uniwebview.com`, `github.com`, `discord.gg`) untouched.
- `CHANGELOG.md`: added `2.0.0` entry.
- `Samples~/BasicIntegration/BoltBasicExample.cs`: the example checkout URL `...c-staging.bolt.com...` → `c-staging.boltapp.com`. **Reviewer note:** this was not in the original change list; I migrated it because it is a subdomain of `bolt.com` (distinct from the excluded `staging-bolt.com`) and leaving it would fail the scope-verification grep. Easy to revert if you'd rather keep the staging example as-is.

### ⚠️ Release gating — do NOT cut the `v2.0.0` tag yet
`play.boltapp.com` does **not** currently resolve (verified: `boltapp.com`, `play.`, `docs.`, `merchant.`, `www.`, `gaming-help.` all fail DNS; `play.bolt.com` resolves). Merging this PR is safe because consumers pin to git tags (`...bolt-unity-sdk.git#vX.Y.Z`) and `main` does not affect them. **The maintainer should hold off creating the `v2.0.0` tag until `play.boltapp.com` is live and serving the ad page** — tagging prematurely would break all production consumers' ad host.

### Verification
`grep -rn "\bbolt\.com" | grep -v "staging-bolt\.com" | grep -v "sandbox-bolt\.com"` returns nothing (except CHANGELOG prose intentionally documenting the `play.bolt.com → play.boltapp.com` change).


Link to Devin session: https://app.devin.ai/sessions/2962167046394f2c8a4cffa9803d1a31
Requested by: @alanthai